### PR TITLE
feat(sandbox): declareComponent flag

### DIFF
--- a/example-app-angular-cli/src/app/shared/notice.component.sandbox.ts
+++ b/example-app-angular-cli/src/app/shared/notice.component.sandbox.ts
@@ -1,3 +1,4 @@
+import { SharedModule } from './shared.module';
 import { sandboxOf } from 'angular-playground';
 import { CounterService } from './counter.service';
 import { NoticeComponent } from './notice.component';
@@ -8,7 +9,7 @@ class MockCounterService {
   }
 }
 
-export default sandboxOf(NoticeComponent, {providers: [CounterService]})
+export default sandboxOf(NoticeComponent, {imports: [SharedModule], declareComponent: false})
   .add('short text', {
     template: `<ex-notice>Notification</ex-notice>`
   })

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -3,6 +3,7 @@ export interface SandboxOfConfig {
   imports?: any[];
   declarations?: any[];
   providers?: any[];
+  declareComponent?: boolean;
 }
 
 export interface ScenarioConfig {
@@ -43,7 +44,8 @@ export class SandboxBuilder {
       prependText: this._config.prependText || '',
       imports: this._config.imports || null,
       declarations: this._config.declarations || null,
-      providers: this._config.providers || null
+      providers: this._config.providers || null,
+      declareComponent: this._config.declareComponent !== undefined ? this._config.declareComponent : true,
     };
   }
 }

--- a/src/app/scenario/scenario.component.ts
+++ b/src/app/scenario/scenario.component.ts
@@ -65,7 +65,7 @@ export class ScenarioComponent {
         imports ? imports : []
       ],
       declarations: [
-        type,
+        ...(sandbox.declareComponent ? [ type ] : []),
         hostComponent,
         declarations ? declarations : []
       ],

--- a/src/app/shared/app-state.ts
+++ b/src/app/shared/app-state.ts
@@ -11,7 +11,8 @@ export interface Sandbox {
   imports?: any[],
   declarations?: any[],
   scenarios: Scenario[],
-  providers?: any[]
+  providers?: any[],
+  declareComponent?: boolean,
 }
 
 export interface Scenario {


### PR DESCRIPTION
declareComponent flag controls whether the sandbox component is declared automatically - defaults to true

I tested on the angular cli example by setting the notice component to use `declareComponent: false`.  The notice component and the other components all render in the playground without error.