### PR TITLE
Feature/latest issues

### DIFF
--- a/example-app-angular-cli/src/main.playground.ts
+++ b/example-app-angular-cli/src/main.playground.ts
@@ -1,5 +1,6 @@
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
-import { initializePlayground, PlaygroundModule } from 'angular-playground';
+import { initializePlayground } from 'angular-playground';
+import { MyPlaygroundModule } from './my-playground.module';
 
 initializePlayground('ng-app');
-platformBrowserDynamic().bootstrapModule(PlaygroundModule);
+platformBrowserDynamic().bootstrapModule(MyPlaygroundModule);

--- a/example-app-angular-cli/src/my-playground.module.ts
+++ b/example-app-angular-cli/src/my-playground.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { AppComponent, PlaygroundCommonModule } from 'angular-playground';
+
+@NgModule({
+  imports: [
+    BrowserModule,
+    BrowserAnimationsModule,
+    PlaygroundCommonModule
+  ],
+  bootstrap: [AppComponent]
+})
+export class MyPlaygroundModule {}

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,5 @@
 export * from './src/api/api';
 export * from './src/api/playground';
 export * from './src/app/playground.module';
+export * from './src/app/playground-common.module';
+export * from './src/app/app.component';

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -104,7 +104,6 @@ import {fuzzySearch} from './shared/fuzzy-search.function';
     }
 
     section {
-      z-index: 1;
       position: relative;
       border: 0;
       width: 100%;

--- a/src/app/playground-common.module.ts
+++ b/src/app/playground-common.module.ts
@@ -1,0 +1,30 @@
+import {NgModule} from '@angular/core';
+import {CommonModule, Location, LocationStrategy, PathLocationStrategy} from '@angular/common';
+import {ReactiveFormsModule} from '@angular/forms';
+import {ScenarioComponent} from './scenario/scenario.component';
+import {SANDBOXES} from './shared/tokens';
+import {StateService} from './shared/state.service';
+import {loadSandboxes} from './load-sandboxes';
+import {FocusDirective} from "./shared/focus.directive";
+import {UrlService} from "./shared/url.service";
+import {AppComponent} from './app.component';
+
+declare let require: any;
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ReactiveFormsModule
+  ],
+  providers: [
+    Location,
+    {provide: LocationStrategy, useClass: PathLocationStrategy},
+    {provide: SANDBOXES, useFactory: loadSandboxes},
+    StateService,
+    UrlService
+  ],
+  declarations: [AppComponent, ScenarioComponent, FocusDirective],
+  exports: [AppComponent]
+})
+export class PlaygroundCommonModule {
+}

--- a/src/app/playground.module.ts
+++ b/src/app/playground.module.ts
@@ -1,40 +1,15 @@
 import {NgModule} from '@angular/core';
-import {Location, LocationStrategy, PathLocationStrategy} from '@angular/common';
-import {ScenarioComponent} from './scenario/scenario.component';
 import {BrowserModule} from '@angular/platform-browser';
-import {ReactiveFormsModule} from '@angular/forms';
 import {AppComponent} from './app.component';
-import {SANDBOXES} from './shared/tokens';
-import {StateService} from './shared/state.service';
-import {loadSandboxes} from './load-sandboxes';
-import {FocusDirective} from "./shared/focus.directive";
-import {UrlService} from "./shared/url.service";
+import {PlaygroundCommonModule} from './playground-common.module';
 
 declare let require: any;
 
-const PLAYGROUND_SUPPORT_MODULES = require('sandboxes').PLAYGROUND_SUPPORT_MODULES;
-
-let imports = [
-  BrowserModule,
-  ReactiveFormsModule
-];
-if(PLAYGROUND_SUPPORT_MODULES.length > 0) {
-  imports = [
-    ...imports,
-    ...PLAYGROUND_SUPPORT_MODULES
-  ];
-}
-
 @NgModule({
-  imports,
-  providers: [
-    Location,
-    {provide: LocationStrategy, useClass: PathLocationStrategy},
-    {provide: SANDBOXES, useFactory: loadSandboxes},
-    StateService,
-    UrlService
+  imports: [
+    BrowserModule,
+    PlaygroundCommonModule
   ],
-  declarations: [AppComponent, ScenarioComponent, FocusDirective],
   bootstrap: [AppComponent]
 })
 export class PlaygroundModule {

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -6,18 +6,6 @@ import * as path from 'path';
 export const build = (rootPath) => {
   let importStatements = new StringBuilder();
   let content = new StringBuilder();
-
-  let modules = [];
-  try {
-    fs.accessSync(path.resolve('node_modules/@angular/animations'));
-    importStatements.addLine(`import { BrowserAnimationsModule } from '@angular/platform-browser/animations';`);
-    modules.push('BrowserAnimationsModule');
-  } catch (e) {
-  }
-  content.addLine('');
-  content.addLine(`export const PLAYGROUND_SUPPORT_MODULES: any[] = [${modules.join(',')}];`);
-
-
   let home = path.resolve(rootPath);
   let sandboxCount = 0;
   let sandboxes = [];


### PR DESCRIPTION
Yo,

This adds a PlaygroundCommonModule and moves the majority of Playground stuff into that, so the root NgModule just has the BrowserModule, PlaygroundCommonModule and the AppComponent bootstrap. This makes it so people can create their own "MyPlaygroundModule" and add anything they need to the root NgModule at that point and just import the PlaygroundCommonModule in the similar fashion.

I think this might be the best way to handle the case of needing to add to that root NgModule to solve issue #32.

The use of PlaygroundModule still works the same for cases where you don't need to do any root NgModule configuration, with the exception being that the code to auto-discover the BrowserAnimationsModule is removed so anyone who was relying on that magic will need to create their own "MyPlaygroundModule" to make that happen (just like the `main.playground.ts` file in the example-angular-cli app in this code base.

This PR also includes the removal of one of the z-index styles that was causing a problem for some (see issue #34)

Let me know what you think. I tried a bunch of other solutions and they all just felt like some new custom hack. This feels more in line with the natural way you do Angular. If you feel good about it I will cut a release and update the angularplayground.it site with docs on how to use it in this fashion.