### PR TITLE
add missing newline to last string in StringBuilder array

### DIFF
--- a/src/cli/string-builder.ts
+++ b/src/cli/string-builder.ts
@@ -7,6 +7,7 @@ export class StringBuilder {
 
   dump() {
     let data = this.lines.join('\n');
+    data += '\n';
     this.lines = [];
     return data;
   }


### PR DESCRIPTION
This is a one line change to keep lint from complaining about missing linefeeds in sandbox.ts.  This change does not handle the case where the StringBuilder array is empty when dump is called.  For the use case this doesn't seem like an issue.  One could add a check for data being an empty string (null check is not required as join is "guaranteed" to return a valid string.