### PR TITLE
Show all components on empty search

### DIFF
--- a/examples/example-app-angular-cli/package.json
+++ b/examples/example-app-angular-cli/package.json
@@ -8,6 +8,7 @@
     "playground:copy": "node ../../scripts/copy.js",
     "playground:run": "node ./node_modules/angular-playground/dist/bin/cli.js",
     "playground": "npm run playground:copy && npm run playground:run",
+    "playground:dev": "npm run build --prefix ../../ && npm run playground",
     "playground2:run": "node ./node_modules/angular-playground/dist/bin/cli.js angular-playground2.json",
     "cli": "ts-node --project ../../src/cli ../../src/cli/cli.ts",
     "cli:build": "ts-node --project ../../src/cli ../../src/cli/cli.ts -no-watch -no-serve",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -241,8 +241,14 @@ export class AppComponent {
     if (!filter) {
       return [];
     }
+
+    if (filter === '*') {
+      return sandboxMenuItems.map((item, i) => Object.assign({}, item, { tabIndex: i }));
+    }
+
     let tabIndex = 0;
     let filterNormalized = filter.toLowerCase();
+
     return sandboxMenuItems
       .reduce((accum, curr) => {
         let searchKeyNormalized = curr.searchKey.toLowerCase();

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -239,10 +239,6 @@ export class AppComponent {
 
   private filterSandboxes(sandboxMenuItems: SandboxMenuItem[], filter: string) {
     if (!filter) {
-      return [];
-    }
-
-    if (filter === '*') {
       return sandboxMenuItems.map((item, i) => Object.assign({}, item, { tabIndex: i }));
     }
 

--- a/src/app/shared/highlight-search-match.pipe.ts
+++ b/src/app/shared/highlight-search-match.pipe.ts
@@ -3,7 +3,10 @@ import { Pipe, PipeTransform } from '@angular/core';
 @Pipe({name: 'apHighlightSearchMatch', pure: false})
 export class HighlightSearchMatchPipe implements PipeTransform {
   transform(value: string, indexMatches: number[], offset = 0): any {
-    if (value == null) return value;
+    // Match null and undefined, but not 0 or ''
+    if (value == null || indexMatches == null) {
+      return value;
+    }
 
     let transformedValue = '';
     let indexes = indexMatches.reduce((a, n) => n >= offset ? [...a, n - offset] : a, []);

--- a/src/app/shared/state.service.ts
+++ b/src/app/shared/state.service.ts
@@ -14,7 +14,8 @@ export class StateService {
   }
 
   getFilter() {
-    return this.filter;
+    // Asterisk to list all results by default
+    return this.filter ? this.filter : '*';
   }
 
   setFilter(value: string) {

--- a/src/app/shared/state.service.ts
+++ b/src/app/shared/state.service.ts
@@ -14,8 +14,7 @@ export class StateService {
   }
 
   getFilter() {
-    // Asterisk to list all results by default
-    return this.filter ? this.filter : '*';
+    return this.filter;
   }
 
   setFilter(value: string) {


### PR DESCRIPTION
Similar to the asterisk in the filter bar, when the search bar is empty all components will be shown from the command bar.