### PR TITLE
Bugfix: IE11 - Broken arrow function and styling

### DIFF
--- a/packages/angular-playground/cli/src/build-sandboxes.ts
+++ b/packages/angular-playground/cli/src/build-sandboxes.ts
@@ -87,7 +87,7 @@ function buildSandboxFileContents(sandboxes: SandboxFileInformation[], home: str
         // Normalize slash syntax for Windows/Unix filepaths
         fullPath = slash(fullPath);
         content.addLine(`case '${key}':`);
-        content.addLine(`  return import( /* webpackMode: "${chunkMode}" */ '${fullPath}').then(_ => _.default.serialize('${key}'));`);
+        content.addLine(`  return import( /* webpackMode: "${chunkMode}" */ '${fullPath}').then(function(_){ return _.default.serialize('${key}'); });`);
     });
     content.addLine(`}`);
     content.addLine(`}`);

--- a/packages/angular-playground/core/src/app.component.css
+++ b/packages/angular-playground/core/src/app.component.css
@@ -85,6 +85,7 @@
       margin-top: 9px;
       overflow: auto;
       position: relative;
+      max-height: calc(100vh - 109px);
     }
 
     .command-bar__sandboxes::-webkit-scrollbar {


### PR DESCRIPTION
## Error in IE11
#### Issue
An arrow function is written to the sandbox files, which IE11 doesn't support, and so Angular Template cannot be run in IE11.  
#### Proposal
Replace it with a regular function.  
**Reminder:** To test this, you'll need to uncomment the IE11 polyfills in polyfills.js and npm install classlist.js.

## Command-Bar Styling in IE11
#### Issue
There is also some styling issues with the command-bar in IE11. Its children can exceed its height which causes them to be partially (due to lack of background colour) visible when it's off-screen. In addition, it also creates a vertical scroll for the page, when other browsers wouldn't have one.  
#### Proposal
Set the max height of the sandboxes' container to the height of the screen, minus the size of its siblings, so it should approximate the intended max-height.