### PR TITLE
Fix invalid regex used by cli when parsing scenario

### DIFF
--- a/packages/angular-playground/cli/src/build-sandboxes.ts
+++ b/packages/angular-playground/cli/src/build-sandboxes.ts
@@ -50,7 +50,7 @@ function findSandboxes(home: string): SandboxFileInformation[] {
             const labelText = /label\s*:\s*['"](.+)['"]/g.exec(matchSandboxOf[0]);
 
             let scenarioMenuItems = [];
-            const scenarioRegex = /\.add\s*\(['"](.+)['"]\s*,\s*{/g;
+            const scenarioRegex = /\.add\s*\(\s*['"](.+)['"]\s*,\s*{/g;
             let scenarioMatches;
             let scenarioIndex = 1;
             while ((scenarioMatches = scenarioRegex.exec(contents)) !== null) {


### PR DESCRIPTION
In the following scenario:
```
export default sandboxOf( MyComponenent )
    .add( 'scenario desc', {
        template: `<my-component></my-component/>`
    } )
```
Note the space between the **add(** and the begenning of the string **'scenario desc'**.

The regex that parse scenario would not have detected it (because of the space).

This just fix that :)
