### PR TITLE
reveal to user thrown error for issue #95

### DIFF
--- a/packages/angular-playground/cli/src/serve-angular-cli.ts
+++ b/packages/angular-playground/cli/src/serve-angular-cli.ts
@@ -3,7 +3,14 @@ import { spawn, SpawnOptions, ChildProcess } from 'child_process';
 import { Config } from './configure';
 
 export async function serveAngularCli(config: Config) {
-    const args: string[] = configureArguments(config);
+    let args: string[];
+
+    try {
+        args = configureArguments(config);
+    } catch (err) {
+        process.stderr.write(err.message + "\n");
+    }
+
     const ngServe = spawn('node', args);
 
     const write = (handler: any, data: any) => {

--- a/packages/angular-playground/cli/src/serve-angular-cli.ts
+++ b/packages/angular-playground/cli/src/serve-angular-cli.ts
@@ -8,7 +8,8 @@ export async function serveAngularCli(config: Config) {
     try {
         args = configureArguments(config);
     } catch (err) {
-        process.stderr.write(err.message + "\n");
+        console.error(err.message);
+        process.exit(1);
     }
 
     const ngServe = spawn('node', args);


### PR DESCRIPTION
It didn't seem quite correct to handle the error in the write function defined a couple lines below. But maybe at I should be adding "[ng serve]" to the beginning of the error message so it matches the other error messages.

I also didn't add process.exit(1) to the catch block but maybe that would be useful.