### PR TITLE
Fix/scenario name same line

### DIFF
--- a/packages/angular-playground/cli/src/build-sandboxes.ts
+++ b/packages/angular-playground/cli/src/build-sandboxes.ts
@@ -45,7 +45,11 @@ export function findSandboxes(home: string): SandboxFileInformation[] {
             const labelText = /label\s*:\s*['"](.+)['"]/g.exec(matchSandboxOf[0]);
 
             let scenarioMenuItems = [];
-            const scenarioRegex = /^(?!\/\/)\s*\.add\s*\(\s*['"](.+)['"]\s*,\s*{/gm;
+
+            // Tested with https://regex101.com/r/mtp2Fy/2
+            // First scenario: May follow directly after sandboxOf function ).add
+            // Other scenarios: .add with possible whitespace before. Ignore outcommented lines.
+            const scenarioRegex = /^(?!\/\/)(?:\s*|.*\))\.add\s*\(\s*['"](.+)['"]\s*,\s*{/gm;
             let scenarioMatches;
             let scenarioIndex = 1;
             while ((scenarioMatches = scenarioRegex.exec(contents)) !== null) {

--- a/packages/angular-playground/cli/test/build-sandboxes.spec.ts
+++ b/packages/angular-playground/cli/test/build-sandboxes.spec.ts
@@ -173,6 +173,6 @@ describe('buildSandboxFileContents', () => {
 describe('slash', () => {
     it('should convert Windows-style path to unix-style', () => {
         const windowsPath = 'c:\\etc\\';
-        expect(slash(windowsPath)).toBe('c:/etc/')
+        expect(slash(windowsPath)).toBe('c:/etc/');
     });
 });

--- a/packages/angular-playground/cli/test/build-sandboxes.spec.ts
+++ b/packages/angular-playground/cli/test/build-sandboxes.spec.ts
@@ -9,17 +9,19 @@ describe('findSandboxes', () => {
     });
 
     it('should find sandbox files and assemble multiple sandboxes', () => {
-        expect(sandboxes.length).toBe(2);
+        expect(sandboxes.length).toBe(3);
     });
 
     it('should create a key that contains the path to the sandbox', () => {
         expect(sandboxes[0].key).toBe('cli/test/files/sandboxes/example1.sandbox');
         expect(sandboxes[1].key).toBe('cli/test/files/sandboxes/example2.sandbox');
+        expect(sandboxes[2].key).toBe('cli/test/files/sandboxes/example3.sandbox');
     });
 
     it('should find the sandbox label among the configuration options', () => {
         expect(sandboxes[0].label).toBe('');
         expect(sandboxes[1].label).toBe('test');
+        expect(sandboxes[2].label).toBe('');
     });
 
     it('should put together correct metadata from a sandbox', () => {
@@ -27,12 +29,20 @@ describe('findSandboxes', () => {
         expect(sandboxes[0].searchKey).toBe('ExampleComponent');
         expect(sandboxes[0].name).toBe('ExampleComponent');
         expect(sandboxes[0].label).toBe('');
+
+        expect(sandboxes[2].key).toBe('cli/test/files/sandboxes/example3.sandbox');
+        expect(sandboxes[2].searchKey).toBe('ThreeDviewComponent');
+        expect(sandboxes[2].name).toBe('ThreeDviewComponent');
+        expect(sandboxes[2].label).toBe('');
     });
 
     it('should find all scenarios associated with a sandbox', () => {
         expect(sandboxes[0].scenarioMenuItems.length).toBe(2);
         expect(sandboxes[0].scenarioMenuItems[0].description).toBe('Default');
         expect(sandboxes[0].scenarioMenuItems[1].description).toBe('With Wrapper');
+
+        expect(sandboxes[2].scenarioMenuItems.length).toBe(1);
+        expect(sandboxes[2].scenarioMenuItems[0].description).toBe('Default');
     });
 
     it('should ignore commented-out scenarios', () => {

--- a/packages/angular-playground/cli/test/build-sandboxes.spec.ts
+++ b/packages/angular-playground/cli/test/build-sandboxes.spec.ts
@@ -9,19 +9,25 @@ describe('findSandboxes', () => {
     });
 
     it('should find sandbox files and assemble multiple sandboxes', () => {
-        expect(sandboxes.length).toBe(3);
+        expect(sandboxes.length).toBe(6);
     });
 
     it('should create a key that contains the path to the sandbox', () => {
         expect(sandboxes[0].key).toBe('cli/test/files/sandboxes/example1.sandbox');
         expect(sandboxes[1].key).toBe('cli/test/files/sandboxes/example2.sandbox');
         expect(sandboxes[2].key).toBe('cli/test/files/sandboxes/example3.sandbox');
+        expect(sandboxes[3].key).toBe('cli/test/files/sandboxes/example4.sandbox');
+        expect(sandboxes[4].key).toBe('cli/test/files/sandboxes/example5.sandbox');
+        expect(sandboxes[5].key).toBe('cli/test/files/sandboxes/example6.sandbox');
     });
 
     it('should find the sandbox label among the configuration options', () => {
         expect(sandboxes[0].label).toBe('');
         expect(sandboxes[1].label).toBe('test');
         expect(sandboxes[2].label).toBe('');
+        expect(sandboxes[3].label).toBe('');
+        expect(sandboxes[4].label).toBe('');
+        expect(sandboxes[5].label).toBe('');
     });
 
     it('should put together correct metadata from a sandbox', () => {
@@ -34,6 +40,21 @@ describe('findSandboxes', () => {
         expect(sandboxes[2].searchKey).toBe('ThreeDviewComponent');
         expect(sandboxes[2].name).toBe('ThreeDviewComponent');
         expect(sandboxes[2].label).toBe('');
+
+        expect(sandboxes[3].key).toBe('cli/test/files/sandboxes/example4.sandbox');
+        expect(sandboxes[3].searchKey).toBe('ThreeDviewComponent');
+        expect(sandboxes[3].name).toBe('ThreeDviewComponent');
+        expect(sandboxes[3].label).toBe('');
+
+        expect(sandboxes[4].key).toBe('cli/test/files/sandboxes/example5.sandbox');
+        expect(sandboxes[4].searchKey).toBe('ThreeDviewComponent');
+        expect(sandboxes[4].name).toBe('ThreeDviewComponent');
+        expect(sandboxes[4].label).toBe('');
+
+        expect(sandboxes[5].key).toBe('cli/test/files/sandboxes/example6.sandbox');
+        expect(sandboxes[5].searchKey).toBe('ThreeDviewComponent');
+        expect(sandboxes[5].name).toBe('ThreeDviewComponent');
+        expect(sandboxes[5].label).toBe('');
     });
 
     it('should find all scenarios associated with a sandbox', () => {
@@ -43,6 +64,15 @@ describe('findSandboxes', () => {
 
         expect(sandboxes[2].scenarioMenuItems.length).toBe(1);
         expect(sandboxes[2].scenarioMenuItems[0].description).toBe('Default');
+
+        expect(sandboxes[3].scenarioMenuItems.length).toBe(1);
+        expect(sandboxes[3].scenarioMenuItems[0].description).toBe('Default');
+
+        expect(sandboxes[4].scenarioMenuItems.length).toBe(1);
+        expect(sandboxes[4].scenarioMenuItems[0].description).toBe('Default');
+
+        expect(sandboxes[5].scenarioMenuItems.length).toBe(1);
+        expect(sandboxes[5].scenarioMenuItems[0].description).toBe('Default');
     });
 
     it('should ignore commented-out scenarios', () => {

--- a/packages/angular-playground/cli/test/files/sandboxes/example3.sandbox.ts
+++ b/packages/angular-playground/cli/test/files/sandboxes/example3.sandbox.ts
@@ -1,0 +1,5 @@
+export default sandboxOf(ThreeDviewComponent).add(
+    'Default', {
+        template: `<app-three-dview></app-three-dview>`
+    }
+);

--- a/packages/angular-playground/cli/test/files/sandboxes/example4.sandbox.ts
+++ b/packages/angular-playground/cli/test/files/sandboxes/example4.sandbox.ts
@@ -1,0 +1,3 @@
+export default sandboxOf(ThreeDviewComponent).add('Default', {
+    template: `<app-three-dview></app-three-dview>`
+});

--- a/packages/angular-playground/cli/test/files/sandboxes/example5.sandbox.ts
+++ b/packages/angular-playground/cli/test/files/sandboxes/example5.sandbox.ts
@@ -1,0 +1,4 @@
+export default sandboxOf(ThreeDviewComponent)
+    .add('Default', {
+        template: `<app-three-dview></app-three-dview>`
+    });

--- a/packages/angular-playground/cli/test/files/sandboxes/example6.sandbox.ts
+++ b/packages/angular-playground/cli/test/files/sandboxes/example6.sandbox.ts
@@ -1,0 +1,6 @@
+export default sandboxOf(ThreeDviewComponent).add(
+    'Default',
+    {
+        template: `<app-three-dview></app-three-dview>`
+    }
+);


### PR DESCRIPTION
This improvement of the scenario name regex should fix a very hard to find bug if e.g. the `.add(` is directly placed behind the `sandboxOf` function. These circumstance could be very problematic if you are using auto-formatters like Prettier on your sandbox files. As workaround you could ignore *.sandbox.ts in .prettierignore. 

Therefore this improvement should fix #107 and #105.

Another suggestion: We may improve the structure of the tests as they currently take multiple scenarios into account. Should we split the tests concerning the example scenarios?