### PR TITLE
Fix invalid assets path when setting up Playground using CLI

### DIFF
--- a/packages/angular-playground/schematics/src/ng-add/index.ts
+++ b/packages/angular-playground/schematics/src/ng-add/index.ts
@@ -45,7 +45,7 @@ function addAppToWorkspaceFile(options: { stylesExtension: string }, workspace: 
           tsConfig: `${normalizedProjectRoot}src/tsconfig.app.json`,
           assets: [
             `${normalizedProjectRoot}src/favicon.ico`,
-            `${normalizedProjectRoot}src/asset`,
+            `${normalizedProjectRoot}src/assets`,
           ],
           styles: [
             `${normalizedProjectRoot}src/styles.${options.stylesExtension}`,


### PR DESCRIPTION
Fixed a typo in the schematic used to setup Angular Playground.