### PR TITLE
Add component library support

### DIFF
--- a/packages/angular-playground/CHANGELOG.md
+++ b/packages/angular-playground/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 5.5.0 (2019-5-10)
+
+<a name="5.5.0"></a>
+
+### Features
+* **config:** Playground now supports using multiple source libraries at once (via the `sourceRoots` property in the configuration)
+
 # 5.4.4 (2019-5-10)
 
 <a name="5.4.4"></a>

--- a/packages/angular-playground/cli/src/configure.ts
+++ b/packages/angular-playground/cli/src/configure.ts
@@ -1,10 +1,10 @@
-import program = require('commander');
+import commander = require('commander');
 import { resolve as resolvePath } from 'path';
 import { existsSync } from 'fs';
 import { REPORT_TYPE } from './error-reporter';
 
 export interface Config {
-    sourceRoot: string;
+    sourceRoots: string[];
     chunk: boolean;
     watch: boolean;
     serve: boolean;
@@ -24,11 +24,18 @@ export interface Config {
     angularCliMaxBuffer?: number;
 }
 
+const splitCommaSeparatedList = (value) => {
+    if (!value) {
+        return ['./src/'];
+    }
+    return value.split(',');
+};
+
 export function configure(argv: any): Config {
-    program
+    commander
         .name('angular-playground')
         .option('-C, --config <path>', 'Configuration file', './angular-playground.json')
-        .option('-S, --src <path>', 'Specify component source directory', './src/')
+        .option('-S, --src <path>', 'Specify component source directories (comma separated list)', splitCommaSeparatedList)
 
         // Build options
         .option('--no-watch', 'Disable sandboxes watch', false)
@@ -51,15 +58,15 @@ export function configure(argv: any): Config {
         .option('--ng-cli-args <list>', 'Additional @angular/cli arguments')
         .option('--ng-cli-max-buffer <maxBuffer>', 'Specify a max buffer (for large apps)');
 
-    program.parse(argv);
-    return applyConfigurationFile(program);
+    commander.parse(argv);
+    return applyConfigurationFile(commander);
 }
 
 export function applyConfigurationFile(program: any): Config {
     const playgroundConfig = loadConfig(program.config);
 
     const config: Config = {
-        sourceRoot: playgroundConfig.sourceRoot || program.src,
+        sourceRoots: playgroundConfig.sourceRoots || program.src,
         chunk: negate(playgroundConfig.noChunk) || program.chunk,
         watch: negate(playgroundConfig.noWatch) || program.watch,
         serve: negate(playgroundConfig.noServe) || program.serve,

--- a/packages/angular-playground/cli/src/configure.ts
+++ b/packages/angular-playground/cli/src/configure.ts
@@ -64,6 +64,12 @@ export function configure(argv: any): Config {
 
 export function applyConfigurationFile(program: any): Config {
     const playgroundConfig = loadConfig(program.config);
+    // TODO: remove this deprecation warning at next major version
+    if (playgroundConfig.sourceRoot) {
+        console.warn('Using `sourceRoot` is deprecated. Please use `sourceRoots` instead.');
+        console.warn('See https://angularplayground.it/docs/api/configuration for more info.');
+        playgroundConfig.sourceRoots = [playgroundConfig.sourceRoot];
+    }
 
     const config: Config = {
         sourceRoots: playgroundConfig.sourceRoots || program.src,

--- a/packages/angular-playground/cli/src/from-dir.ts
+++ b/packages/angular-playground/cli/src/from-dir.ts
@@ -1,11 +1,17 @@
 import { existsSync, readdirSync, lstatSync } from 'fs';
 import { join as joinPath } from 'path';
 
+export function fromDirMultiple(startPaths: string[], filter: RegExp, callback: Function) {
+    for (const path of startPaths) {
+        fromDir(path, path, filter, callback);
+    }
+}
+
 /**
  * Recursively apply callback to files in a directory (and sub-directories) that match the
  * provided regular expression
  */
-export function fromDir (startPath: string, filter: RegExp, callback: Function) {
+function fromDir(rootPath: string, startPath: string, filter: RegExp, callback: Function) {
   if (!existsSync(startPath)) {
       throw new Error(`No Directory Found: ${startPath}`);
   }
@@ -16,9 +22,9 @@ export function fromDir (startPath: string, filter: RegExp, callback: Function) 
       const stat = lstatSync(filename);
 
       if (stat.isDirectory()) {
-          fromDir(filename, filter, callback);
+          fromDir(rootPath, filename, filter, callback);
       } else if (filter.test(filename)) {
-          callback(filename);
+          callback(filename, rootPath);
       }
   }
 }

--- a/packages/angular-playground/cli/src/run.ts
+++ b/packages/angular-playground/cli/src/run.ts
@@ -10,7 +10,7 @@ export async function run() {
     const config: Config = configure(process.argv);
 
     try {
-        await buildSandboxes(config.sourceRoot, config.chunk);
+        await buildSandboxes(config.sourceRoots, config.chunk);
     } catch (err) {
         throw err;
     }
@@ -24,7 +24,7 @@ export async function run() {
     }
 
     if (config.watch || config.verifySandboxes) {
-        startWatch(config.sourceRoot, () => buildSandboxes(config.sourceRoot, config.chunk));
+        startWatch(config.sourceRoots, () => buildSandboxes(config.sourceRoots, config.chunk));
     }
 
     if (config.serve || config.verifySandboxes) {

--- a/packages/angular-playground/cli/src/start-watch.ts
+++ b/packages/angular-playground/cli/src/start-watch.ts
@@ -1,7 +1,7 @@
 import { resolve as resolvePath } from 'path';
 import watch = require('node-watch');
 
-export function startWatch(sourceRoot: string, cb: Function) {
+export function startWatch(sourceRoots: string[], cb: Function) {
     const filter = (fn: Function) => {
         return (evt: string, filename: string) => {
             if (!/node_modules/.test(filename) && /\.sandbox.ts$/.test(filename)) {
@@ -10,5 +10,6 @@ export function startWatch(sourceRoot: string, cb: Function) {
         };
     };
 
-    watch([resolvePath(sourceRoot)], { recursive: true }, filter(cb));
+    const sourceRootPaths = sourceRoots.map(sourceRoot => resolvePath(sourceRoot));
+    watch(sourceRootPaths, { recursive: true }, filter(cb));
 }

--- a/packages/angular-playground/cli/test/build-sandboxes.spec.ts
+++ b/packages/angular-playground/cli/test/build-sandboxes.spec.ts
@@ -4,11 +4,11 @@ describe('findSandboxes', () => {
     let sandboxes;
 
     beforeEach(() => {
-        sandboxes = findSandboxes('./cli/test/files/sandboxes/');
+        sandboxes = findSandboxes(['./cli/test/files/sandboxes/', './cli/test/files/sandboxes-2/']);
     });
 
     it('should find sandbox files and assemble multiple sandboxes', () => {
-        expect(sandboxes.length).toBe(6);
+        expect(sandboxes.length).toBe(12);
     });
 
     it('should create a key that contains the path to the sandbox', () => {
@@ -97,6 +97,7 @@ describe('buildSandboxFileContents', () => {
         sandboxes = [
             {
                 key: 'cli/test/files/sandboxes/example1.sandbox',
+                srcPath: 'home/',
                 searchKey: 'ExampleComponent',
                 name: 'ExampleComponent',
                 label: '',
@@ -113,6 +114,7 @@ describe('buildSandboxFileContents', () => {
             },
             {
                 key: 'cli/test/files/sandboxes/other.sandbox',
+                srcPath: 'other-home/',
                 searchKey: 'OtherComponent',
                 name: 'OtherComponent',
                 label: '',
@@ -128,19 +130,19 @@ describe('buildSandboxFileContents', () => {
 
     describe('exported functions', () => {
         it('should return a function, getSandboxMenuItems, with the JSON string contents of the sandboxes', () => {
-            const fileContents = buildSandboxFileContents(sandboxes, 'home/', 'lazy');
+            const fileContents = buildSandboxFileContents(sandboxes, 'lazy');
             expect(fileContents).toContain(JSON.stringify(sandboxes));
         });
 
         it('should return a function, getSandbox, that includes imports to sandbox files', () => {
-            const fileContents = buildSandboxFileContents(sandboxes, 'home/', 'lazy');
+            const fileContents = buildSandboxFileContents(sandboxes, 'lazy');
             expect(fileContents).toContain('import( /* webpackMode: "lazy" */ \'home/cli/test/files/sandboxes/example1.sandbox\')');
             expect(fileContents).toContain('import( /* webpackMode: "lazy" */ \'home/cli/test/files/sandboxes/other.sandbox\')');
         });
 
 
         it('should include exports for both sandbox-fetching functions', () => {
-            const fileContents = buildSandboxFileContents(sandboxes, 'home/', 'eager');
+            const fileContents = buildSandboxFileContents(sandboxes, 'eager');
             expect(fileContents).toContain('exports.getSandboxMenuItems = getSandboxMenuItems;');
             expect(fileContents).toContain('exports.getSandbox = getSandbox;');
         });
@@ -148,7 +150,7 @@ describe('buildSandboxFileContents', () => {
 
     describe('getSandbox', () => {
         it('should return the serialized sandbox', () => {
-            const fileContents = buildSandboxFileContents(sandboxes, 'home/', 'lazy');
+            const fileContents = buildSandboxFileContents(sandboxes, 'lazy');
             expect(fileContents).toContain('return _.default.serialize(\'cli/test/files/sandboxes/example1.sandbox\')');
             expect(fileContents).toContain('return _.default.serialize(\'cli/test/files/sandboxes/other.sandbox\')');
         });
@@ -156,22 +158,22 @@ describe('buildSandboxFileContents', () => {
 
     describe('webpack strategy', () => {
         it('should use lazy webpack resolution strategy if lazy is provided as a parameter', () => {
-            const fileContents = buildSandboxFileContents(sandboxes, 'home/', 'lazy');
+            const fileContents = buildSandboxFileContents(sandboxes, 'lazy');
             expect(fileContents).toContain('import( /* webpackMode: "lazy" */ \'home/cli/test/files/sandboxes/example1.sandbox\')');
             expect(fileContents).not.toContain('eager');
         });
 
         it('should use eager webpack resolution strategy if lazy is provided as a parameter', () => {
-            const fileContents = buildSandboxFileContents(sandboxes, 'home/', 'eager');
+            const fileContents = buildSandboxFileContents(sandboxes, 'eager');
             expect(fileContents).toContain('import( /* webpackMode: "eager" */ \'home/cli/test/files/sandboxes/example1.sandbox\')');
             expect(fileContents).not.toContain('lazy');
         });
     });
-});
 
-describe('slash', () => {
-    it('should convert Windows-style path to unix-style', () => {
-        const windowsPath = 'c:\\etc\\';
-        expect(slash(windowsPath)).toBe('c:/etc/');
+    describe('slash', () => {
+        it('should convert Windows-style path to unix-style', () => {
+            const windowsPath = 'c:\\etc\\';
+            expect(slash(windowsPath)).toBe('c:/etc/');
+        });
     });
 });

--- a/packages/angular-playground/cli/test/build-sandboxes.spec.ts
+++ b/packages/angular-playground/cli/test/build-sandboxes.spec.ts
@@ -137,7 +137,7 @@ describe('buildSandboxFileContents', () => {
         it('should return a function, getSandbox, that includes imports to sandbox files', () => {
             const fileContents = buildSandboxFileContents(sandboxes, 'lazy');
             expect(fileContents).toContain('import( /* webpackMode: "lazy" */ \'home/cli/test/files/sandboxes/example1.sandbox\')');
-            expect(fileContents).toContain('import( /* webpackMode: "lazy" */ \'home/cli/test/files/sandboxes/other.sandbox\')');
+            expect(fileContents).toContain('import( /* webpackMode: "lazy" */ \'other-home/cli/test/files/sandboxes/other.sandbox\')');
         });
 
 

--- a/packages/angular-playground/cli/test/configure.spec.ts
+++ b/packages/angular-playground/cli/test/configure.spec.ts
@@ -1,6 +1,6 @@
 import { applyConfigurationFile, Config } from '../src/configure';
 
-describe('applyConfigurationFile', () => {
+describe('configure', () => {
     it('should throw error when failing to load a configuration file', () => {
         const programMock = { config: './no-config.json' };
 
@@ -22,7 +22,7 @@ describe('applyConfigurationFile', () => {
             // Defaults provided from commander
             const programMock = {
                 config: './cli/test/files/empty-config.json',
-                src: './src/',
+                src: ['./src/'],
                 watch: true,
                 serve: true,
                 chunk: true,
@@ -35,7 +35,7 @@ describe('applyConfigurationFile', () => {
 
         describe('have defaults', () => {
             it('should provide default value for source path', () => {
-                expect(config.sourceRoot).toBe('./src/');
+                expect(config.sourceRoots).toEqual(['./src/']);
             });
 
             it('should provide default value for no-watch', () => {

--- a/packages/angular-playground/cli/test/files/from-dir-test-multiple/sub-dir/sub-dir-2/test3.ts
+++ b/packages/angular-playground/cli/test/files/from-dir-test-multiple/sub-dir/sub-dir-2/test3.ts
@@ -1,0 +1,6 @@
+const foo3 = (bar: string) => {
+    const n = bar.length;
+    return Math.pow(n, 2);
+};
+
+export default foo3;

--- a/packages/angular-playground/cli/test/files/from-dir-test-multiple/sub-dir/test2.ts
+++ b/packages/angular-playground/cli/test/files/from-dir-test-multiple/sub-dir/test2.ts
@@ -1,0 +1,6 @@
+const foo2 = (bar: string) => {
+    const n = bar.length;
+    return Math.pow(n, 2);
+};
+
+export default foo2;

--- a/packages/angular-playground/cli/test/files/from-dir-test-multiple/test.ts
+++ b/packages/angular-playground/cli/test/files/from-dir-test-multiple/test.ts
@@ -1,0 +1,6 @@
+const foo = (bar: string) => {
+    const n = bar.length;
+    return Math.pow(n, 2);
+};
+
+export default foo;

--- a/packages/angular-playground/cli/test/files/sandboxes-2/example1.sandbox.ts
+++ b/packages/angular-playground/cli/test/files/sandboxes-2/example1.sandbox.ts
@@ -1,0 +1,13 @@
+export default sandboxOf(ExampleComponent, {
+    imports: [ReactiveFormsModule]
+})
+    .add('Default', {
+        template: `<app-example></app-example>`
+    })
+    .add('With Wrapper', {
+        template: `
+            <div>
+                <app-example></app-example>
+            </div>
+        `
+    });

--- a/packages/angular-playground/cli/test/files/sandboxes-2/example2.sandbox.ts
+++ b/packages/angular-playground/cli/test/files/sandboxes-2/example2.sandbox.ts
@@ -1,0 +1,14 @@
+export default sandboxOf(Example2Component, {
+    imports: [],
+    declarations: [],
+    label: 'test'
+})
+    .add('Other', {
+        template: `<app-example-02></app-example-02>`
+    })
+    // .add('Commented out', {
+    //     template: `<app-example></app-example>`
+    // })
+    .add('An other!', {
+        template: `<app-example-02></app-example-02>`
+    });

--- a/packages/angular-playground/cli/test/files/sandboxes-2/example3.sandbox.ts
+++ b/packages/angular-playground/cli/test/files/sandboxes-2/example3.sandbox.ts
@@ -1,0 +1,5 @@
+export default sandboxOf(ThreeDviewComponent).add(
+    'Default', {
+        template: `<app-three-dview></app-three-dview>`
+    }
+);

--- a/packages/angular-playground/cli/test/files/sandboxes-2/example4.sandbox.ts
+++ b/packages/angular-playground/cli/test/files/sandboxes-2/example4.sandbox.ts
@@ -1,0 +1,3 @@
+export default sandboxOf(ThreeDviewComponent).add('Default', {
+    template: `<app-three-dview></app-three-dview>`
+});

--- a/packages/angular-playground/cli/test/files/sandboxes-2/example5.sandbox.ts
+++ b/packages/angular-playground/cli/test/files/sandboxes-2/example5.sandbox.ts
@@ -1,0 +1,4 @@
+export default sandboxOf(ThreeDviewComponent)
+    .add('Default', {
+        template: `<app-three-dview></app-three-dview>`
+    });

--- a/packages/angular-playground/cli/test/files/sandboxes-2/example6.sandbox.ts
+++ b/packages/angular-playground/cli/test/files/sandboxes-2/example6.sandbox.ts
@@ -1,0 +1,6 @@
+export default sandboxOf(ThreeDviewComponent).add(
+    'Default',
+    {
+        template: `<app-three-dview></app-three-dview>`
+    }
+);

--- a/packages/angular-playground/cli/test/from-dir.spec.ts
+++ b/packages/angular-playground/cli/test/from-dir.spec.ts
@@ -1,12 +1,12 @@
-import { fromDir } from '../src/from-dir';
+import { fromDirMultiple } from '../src/from-dir';
 
 describe('fromDir', () => {
     const dir = './cli/test/files/from-dir-test/';
+    const dir2 = './cli/test/files/from-dir-test-multiple/';
 
     it('should throw error when directory does not exist', () => {
         const t = () => {
-            fromDir('foo', /test/, () => {
-            });
+            fromDirMultiple(['foo'], /test/, () => {});
         };
         expect(t).toThrow();
     });
@@ -14,7 +14,8 @@ describe('fromDir', () => {
     it('should apply callback to each file process matching regex', () => {
         const regex = /\.json$/;
         const mockCb = jest.fn();
-        fromDir(dir, regex, mockCb);
+
+        fromDirMultiple([dir], regex, mockCb);
         expect(mockCb.mock.calls.length).toBe(2);
     });
 
@@ -22,7 +23,7 @@ describe('fromDir', () => {
         const regex = /\.spec.ts$/;
         const mockCb = jest.fn();
 
-        fromDir(dir, regex, mockCb);
+        fromDirMultiple([dir], regex, mockCb);
         expect(mockCb.mock.calls.length).toBe(0);
     });
 
@@ -30,7 +31,15 @@ describe('fromDir', () => {
         const regex = /\.csv$/;
         const mockCb = jest.fn();
 
-        fromDir(dir, regex, mockCb);
+        fromDirMultiple([dir], regex, mockCb);
         expect(mockCb.mock.calls.length).toBe(1);
+    });
+
+    it('should work for multiple directories', () => {
+        const regex = /\.(json|ts)$/;
+        const mockCb = jest.fn();
+
+        fromDirMultiple([dir, dir2], regex, mockCb);
+        expect(mockCb.mock.calls.length).toBe(5);
     });
 });

--- a/packages/angular-playground/package-lock.json
+++ b/packages/angular-playground/package-lock.json
@@ -2339,7 +2339,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2357,11 +2358,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2374,15 +2377,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2485,7 +2491,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2495,6 +2502,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2507,17 +2515,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2534,6 +2545,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2606,7 +2618,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2616,6 +2629,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2691,7 +2705,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2721,6 +2736,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2738,6 +2754,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2776,11 +2793,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/packages/angular-playground/package-lock.json
+++ b/packages/angular-playground/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-playground",
-  "version": "5.4.4",
+  "version": "5.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/angular-playground/package.json
+++ b/packages/angular-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-playground",
-  "version": "5.4.4",
+  "version": "5.5.0",
   "description": "A drop in app module for working on Angular components in isolation (aka Scenario Driven Development).",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/angular-playground/schematics/src/ng-add/files/angular-playground.json
+++ b/packages/angular-playground/schematics/src/ng-add/files/angular-playground.json
@@ -1,5 +1,5 @@
 {
-  "sourceRoot": "./<%= sourceRoot %>",
+  "sourceRoots": ["./<%= sourceRoots %>"],
   "angularCli": {
     "appName": "playground"
   }

--- a/packages/angular-playground/schematics/src/ng-add/index.spec.ts
+++ b/packages/angular-playground/schematics/src/ng-add/index.spec.ts
@@ -41,7 +41,7 @@ describe('ng-add', () => {
 
     // angular-playground.json
     const angularPlaygroundJson = getJsonFileAsObject(resultTree, 'angular-playground.json');
-    expect(angularPlaygroundJson.sourceRoot).toBe('./src');
+    expect(angularPlaygroundJson.sourceRoots).toEqual(['./src']);
     expect(angularPlaygroundJson.angularCli.appName).toBe('playground');
 
     // main.playground.ts
@@ -84,7 +84,7 @@ describe('ng-add', () => {
 
     // angular-playground.json
     const angularPlaygroundJson = getJsonFileAsObject(resultTree, 'angular-playground.json');
-    expect(angularPlaygroundJson.sourceRoot).toBe('./projects/something/src');
+    expect(angularPlaygroundJson.sourceRoots).toEqual(['./projects/something/src']);
     expect(angularPlaygroundJson.angularCli.appName).toBe('playground');
 
     // main.playground.ts
@@ -126,7 +126,7 @@ describe('ng-add', () => {
 
     // angular-playground.json
     const angularPlaygroundJson = getJsonFileAsObject(resultTree, 'angular-playground.json');
-    expect(angularPlaygroundJson.sourceRoot).toBe('./src');
+    expect(angularPlaygroundJson.sourceRoots).toEqual(['./src']);
     expect(angularPlaygroundJson.angularCli.appName).toBe('playground');
 
     // main.playground.ts

--- a/packages/angular-playground/schematics/src/ng-add/index.ts
+++ b/packages/angular-playground/schematics/src/ng-add/index.ts
@@ -134,7 +134,7 @@ function createNewFiles(options: any): Rule {
       filter(path => path.endsWith('angular-playground.json')),
       template({
         ...strings,
-        sourceRoot,
+        sourceRoots: [sourceRoot],
       }),
     ]);
     const playgroundMainTemplateSource = apply(url('./files'), [

--- a/packages/angular-playground/schematics/src/ng-add/index.ts
+++ b/packages/angular-playground/schematics/src/ng-add/index.ts
@@ -43,7 +43,7 @@ function addAppToWorkspaceFile(options: { stylesExtension: string }, workspace: 
   const projectRoot = normalize(project.root);
   const sourceRoot = getSourceRoot(project.sourceRoot);
   const sourceRootParts = sourceRoot.split('/');
-  const tsConfigPath = projectRoot === '' ? 'src' : projectRoot;
+  const tsConfigPath = projectRoot === '' ? sourceRoot : projectRoot;
   const tsConfigPathParts = tsConfigPath.split('/');
 
   const newProject: Partial<WorkspaceProject> = {


### PR DESCRIPTION
adds support for playground to watch and pull sandboxes from multiple source directories (an angular app + external angular libraries)

closes #143 