### PR TITLE
fix error reporter having empty errors

### DIFF
--- a/examples/cli-example/src/app/feature1/person-block.component.ts
+++ b/examples/cli-example/src/app/feature1/person-block.component.ts
@@ -9,6 +9,6 @@ export class PersonBlockComponent {
   person;
 
   constructor() {
-    this.person = { fullName: 'Justin Schwartzenberger', twitterHandle: 'schwarty'}
+    this.person = { fullName: 'Justin Schwartzenberger', twitterHandle: 'schwarty'};
   }
 }

--- a/packages/angular-playground/cli/src/check-errors/reporters/xml-reporter.ts
+++ b/packages/angular-playground/cli/src/check-errors/reporters/xml-reporter.ts
@@ -25,6 +25,9 @@ export class XMLReporter implements Reporter {
     }
 
     private htmlEncode(s: string) {
+        if (!s) {
+            return '';
+        }
         return s
             .replace(/&/g, '&amp;')
             .replace(/"/g, '&quot;')

--- a/packages/angular-playground/cli/src/check-errors/verify-sandboxes.ts
+++ b/packages/angular-playground/cli/src/check-errors/verify-sandboxes.ts
@@ -140,12 +140,17 @@ function loadSandboxMenuItems(): SandboxFileInformation[] {
 function onConsoleErr(msg: ConsoleMessage) {
     if (msg.type() === 'error') {
         console.error(chalk.red(`Error in ${currentScenario} (${currentScenarioDescription}):`));
-        const descriptions = msg.args()
+        const getErrors = (type: string, getValue: (_: any) => string) => msg.args()
             .map(a => (a as any)._remoteObject)
-            .filter(o => o.type === 'object')
-            .map(o => o.description);
-        descriptions.map(d => console.error(d));
-        reporter.addError(descriptions, currentScenario, currentScenarioDescription);
+            .filter(o => o.type === type)
+            .map(getValue);
+        const stackTrace = getErrors('object', o => o.description);
+        const errorMessage = getErrors('string', o => o.value);
+        const description = stackTrace.length ? stackTrace : errorMessage;
+        description.map(d => console.error(d));
+        if (description.length) {
+            reporter.addError(description, currentScenario, currentScenarioDescription);
+        }
     }
 }
 

--- a/packages/angular-playground/cli/test/error-reporter.spec.ts
+++ b/packages/angular-playground/cli/test/error-reporter.spec.ts
@@ -45,4 +45,13 @@ describe('ErrorReporter', () => {
         reporter.compileReport();
         expect(writeFileSpy).toHaveBeenCalled();
     });
+
+    it('should write to file if report type is xml', () => {
+        const writeFileSpy = spyOn(fs, 'writeFileSync');
+        reporter.type = REPORT_TYPE.XML;
+        reporter.addError('LOG Error', 'http://localhost:4201/textbox');
+        reporter.addError('Read Error', 'http://localhost:4201/textbox');
+        reporter.compileReport();
+        expect(writeFileSpy).toHaveBeenCalled();
+    });
 });


### PR DESCRIPTION
look for string errors in case there isn't a stack trace (happens when just a `string` is thrown, instead of an `Error()`)

closes #182 