### PR TITLE
add config so jest does not ignore the test file

### DIFF
--- a/packages/angular-playground/CHANGELOG.md
+++ b/packages/angular-playground/CHANGELOG.md
@@ -1,8 +1,15 @@
+# 5.8.2 (2019-6-15)
+
+<a name="5.8.2"></a>
+
+### Bug Fixes
+* **visual regressions:** Make jest not ignore the `test.js` file used for testing visual regressions
+
 # 5.8.1 (2019-6-14)
 
 <a name="5.8.1"></a>
 
-### Features
+### Bug Fixes
 * **visual regressions:** Include jest config files needed for testing visual regressions
 
 # 5.8.0 (2019-6-14)

--- a/packages/angular-playground/jest/jest-puppeteer.config.js
+++ b/packages/angular-playground/jest/jest-puppeteer.config.js
@@ -1,5 +1,9 @@
 module.exports = {
   preset: 'jest-puppeteer',
-  testRegex: 'test\\.js$',
   setupFilesAfterEnv: ['./setup-tests.js'],
+  testRegex: 'test\\.js$',
+  testPathIgnorePatterns: [],
+  haste: {
+    providesModuleNodeModules: ['angular-playground']
+  }
 };

--- a/packages/angular-playground/package-lock.json
+++ b/packages/angular-playground/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "angular-playground",
-    "version": "5.8.1",
+    "version": "5.8.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/packages/angular-playground/package.json
+++ b/packages/angular-playground/package.json
@@ -1,6 +1,6 @@
 {
     "name": "angular-playground",
-    "version": "5.8.1",
+    "version": "5.8.2",
     "description": "A drop in app module for working on Angular components in isolation (aka Scenario Driven Development).",
     "main": "dist/index.js",
     "typings": "dist/index.d.ts",


### PR DESCRIPTION
jest was previously ignoring the `test.js` file since it was in a subdirectory of node_modules. for some reason this didn't happen when I was testing via `npm link`ing playground, only when playground was installed from npm. regardless, it's fixed now.