### PR TITLE
Fix ng add bug

### DIFF
--- a/packages/angular-playground/CHANGELOG.md
+++ b/packages/angular-playground/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 6.0.2 (2019-9-25)
+
+<a name="6.0.2"></a>
+
+### Features
+* **ng add:** Fix error during ng add when first project is a library
+
 # 6.0.1 (2019-7-18)
 
 <a name="6.0.1"></a>

--- a/packages/angular-playground/package-lock.json
+++ b/packages/angular-playground/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "angular-playground",
-    "version": "6.0.1",
+    "version": "6.0.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/packages/angular-playground/package.json
+++ b/packages/angular-playground/package.json
@@ -1,6 +1,6 @@
 {
     "name": "angular-playground",
-    "version": "6.0.1",
+    "version": "6.0.2",
     "description": "A drop in app module for working on Angular components in isolation (aka Scenario Driven Development).",
     "main": "dist/index.js",
     "typings": "dist/index.d.ts",

--- a/packages/angular-playground/schematics/src/ng-add/index.spec.ts
+++ b/packages/angular-playground/schematics/src/ng-add/index.spec.ts
@@ -15,14 +15,11 @@ describe('ng-add', () => {
     tree.create('package.json', createPackageJson());
     const runner = new SchematicTestRunner('schematics', collectionPath);
     const resultTree = runner.runSchematic('ng-add', {}, tree);
+    verifyBasicFiles(resultTree, {
+      sourceRootPath: './src',
+      mainFilePath: 'src/main.playground.ts',
+    });
 
-    // package.json
-    const packageJson = getJsonFileAsObject(resultTree, 'package.json');
-    expect(packageJson.scripts['playground']).toBe('angular-playground');
-    expect(packageJson.dependencies['angular-playground']).toBeUndefined();
-    expect(packageJson.devDependencies['angular-playground']).toBe('1.2.3');
-
-    // angular.json
     const angularJson = getJsonFileAsObject(resultTree, 'angular.json');
     expect(angularJson.projects.playground.root).toBe('');
     expect(angularJson.projects.playground.sourceRoot).toBe('src');
@@ -38,15 +35,6 @@ describe('ng-add', () => {
       .toBe('src/environments/environment.ts');
     expect(angularJson.projects.playground.architect.build.configurations.production.fileReplacements[0].with)
       .toBe('src/environments/environment.prod.ts');
-
-    // angular-playground.json
-    const angularPlaygroundJson = getJsonFileAsObject(resultTree, 'angular-playground.json');
-    expect(angularPlaygroundJson.sourceRoots).toEqual(['./src']);
-    expect(angularPlaygroundJson.angularCli.appName).toBe('playground');
-
-    // main.playground.ts
-    const mainFile = resultTree.readContent('src/main.playground.ts');
-    expect(mainFile).toBeTruthy();
   });
   it('should work for a project created with `ng g app`', () => {
     const tree = Tree.empty();
@@ -58,14 +46,11 @@ describe('ng-add', () => {
     tree.create('package.json', createPackageJson());
     const runner = new SchematicTestRunner('schematics', collectionPath);
     const resultTree = runner.runSchematic('ng-add', {}, tree);
+    verifyBasicFiles(resultTree, {
+      sourceRootPath: './projects/something/src',
+      mainFilePath: 'projects/something/src/main.playground.ts',
+    });
 
-    // package.json
-    const packageJson = getJsonFileAsObject(resultTree, 'package.json');
-    expect(packageJson.scripts['playground']).toBe('angular-playground');
-    expect(packageJson.dependencies['angular-playground']).toBeUndefined();
-    expect(packageJson.devDependencies['angular-playground']).toBe('1.2.3');
-
-    // angular.json
     const angularJson = getJsonFileAsObject(resultTree, 'angular.json');
     expect(angularJson.projects.playground.root).toBe('projects/something');
     expect(angularJson.projects.playground.sourceRoot).toBe('projects/something/src');
@@ -81,14 +66,6 @@ describe('ng-add', () => {
       .toBe('projects/something/src/environments/environment.ts');
     expect(angularJson.projects.playground.architect.build.configurations.production.fileReplacements[0].with)
       .toBe('projects/something/src/environments/environment.prod.ts');
-
-    // angular-playground.json
-    const angularPlaygroundJson = getJsonFileAsObject(resultTree, 'angular-playground.json');
-    expect(angularPlaygroundJson.sourceRoots).toEqual(['./projects/something/src']);
-    expect(angularPlaygroundJson.angularCli.appName).toBe('playground');
-
-    // main.playground.ts
-    expect(resultTree.files).toContain('/projects/something/src/main.playground.ts');
   });
   it('should work for a project with a non-default style extension', () => {
     const tree = Tree.empty();
@@ -100,14 +77,11 @@ describe('ng-add', () => {
     tree.create('package.json', createPackageJson());
     const runner = new SchematicTestRunner('schematics', collectionPath);
     const resultTree = runner.runSchematic('ng-add', {}, tree);
+    verifyBasicFiles(resultTree, {
+      sourceRootPath: './src',
+      mainFilePath: 'src/main.playground.ts',
+    });
 
-    // package.json
-    const packageJson = getJsonFileAsObject(resultTree, 'package.json');
-    expect(packageJson.scripts['playground']).toBe('angular-playground');
-    expect(packageJson.dependencies['angular-playground']).toBeUndefined();
-    expect(packageJson.devDependencies['angular-playground']).toBe('1.2.3');
-
-    // angular.json
     const angularJson = getJsonFileAsObject(resultTree, 'angular.json');
     expect(angularJson.projects.playground.root).toBe('');
     expect(angularJson.projects.playground.sourceRoot).toBe('src');
@@ -123,15 +97,6 @@ describe('ng-add', () => {
       .toBe('src/environments/environment.ts');
     expect(angularJson.projects.playground.architect.build.configurations.production.fileReplacements[0].with)
       .toBe('src/environments/environment.prod.ts');
-
-    // angular-playground.json
-    const angularPlaygroundJson = getJsonFileAsObject(resultTree, 'angular-playground.json');
-    expect(angularPlaygroundJson.sourceRoots).toEqual(['./src']);
-    expect(angularPlaygroundJson.angularCli.appName).toBe('playground');
-
-    // main.playground.ts
-    const mainFile = resultTree.readContent('src/main.playground.ts');
-    expect(mainFile).toBeTruthy();
   });
   it('should work for a project that contains only a library', () => {
     const tree = Tree.empty();
@@ -139,14 +104,11 @@ describe('ng-add', () => {
     tree.create('package.json', createPackageJson());
     const runner = new SchematicTestRunner('schematics', collectionPath);
     const resultTree = runner.runSchematic('ng-add', {}, tree);
+    verifyBasicFiles(resultTree, {
+      sourceRootPath: './projects/foo-lib/src',
+      mainFilePath: 'projects/foo-lib/src/main.playground.ts',
+    });
 
-    // package.json
-    const packageJson = getJsonFileAsObject(resultTree, 'package.json');
-    expect(packageJson.scripts['playground']).toBe('angular-playground');
-    expect(packageJson.dependencies['angular-playground']).toBeUndefined();
-    expect(packageJson.devDependencies['angular-playground']).toBe('1.2.3');
-
-    // angular.json
     const angularJson = getJsonFileAsObject(resultTree, 'angular.json');
     expect(angularJson.projects.playground.root).toBe('projects/foo-lib');
     expect(angularJson.projects.playground.sourceRoot).toBe('projects/foo-lib/src');
@@ -162,15 +124,6 @@ describe('ng-add', () => {
       .toBe('projects/foo-lib/src/environments/environment.ts');
     expect(angularJson.projects.playground.architect.build.configurations.production.fileReplacements[0].with)
       .toBe('projects/foo-lib/src/environments/environment.prod.ts');
-
-    // angular-playground.json
-    const angularPlaygroundJson = getJsonFileAsObject(resultTree, 'angular-playground.json');
-    expect(angularPlaygroundJson.sourceRoots).toEqual(['./projects/foo-lib/src']);
-    expect(angularPlaygroundJson.angularCli.appName).toBe('playground');
-
-    // main.playground.ts
-    const mainFile = resultTree.readContent('projects/foo-lib/src/main.playground.ts');
-    expect(mainFile).toBeTruthy();
   });
   it('should work for a project that contains a library followed by an application', () => {
     const tree = Tree.empty();
@@ -178,14 +131,11 @@ describe('ng-add', () => {
     tree.create('package.json', createPackageJson());
     const runner = new SchematicTestRunner('schematics', collectionPath);
     const resultTree = runner.runSchematic('ng-add', {}, tree);
+    verifyBasicFiles(resultTree, {
+      sourceRootPath: './projects/foo-lib-tester/src',
+      mainFilePath: 'projects/foo-lib-tester/src/main.playground.ts',
+    });
 
-    // package.json
-    const packageJson = getJsonFileAsObject(resultTree, 'package.json');
-    expect(packageJson.scripts['playground']).toBe('angular-playground');
-    expect(packageJson.dependencies['angular-playground']).toBeUndefined();
-    expect(packageJson.devDependencies['angular-playground']).toBe('1.2.3');
-
-    // angular.json
     const angularJson = getJsonFileAsObject(resultTree, 'angular.json');
     expect(angularJson.projects.playground.root).toBe('projects/foo-lib-tester');
     expect(angularJson.projects.playground.sourceRoot).toBe('projects/foo-lib-tester/src');
@@ -201,22 +151,11 @@ describe('ng-add', () => {
       .toBe('projects/foo-lib-tester/src/environments/environment.ts');
     expect(angularJson.projects.playground.architect.build.configurations.production.fileReplacements[0].with)
       .toBe('projects/foo-lib-tester/src/environments/environment.prod.ts');
-
-    // angular-playground.json
-    const angularPlaygroundJson = getJsonFileAsObject(resultTree, 'angular-playground.json');
-    expect(angularPlaygroundJson.sourceRoots).toEqual(['./projects/foo-lib-tester/src']);
-    expect(angularPlaygroundJson.angularCli.appName).toBe('playground');
-
-    // main.playground.ts
-    const mainFile = resultTree.readContent('projects/foo-lib-tester/src/main.playground.ts');
-    expect(mainFile).toBeTruthy();
   });
   it('should throw if there are no projects', () => {
     const runner = new SchematicTestRunner('schematics', collectionPath);
     const tree = Tree.empty();
-    tree.create('angular.json', `{
-      "projects": {}
-    }`);
+    tree.create('angular.json', '{ "projects": {} }');
     expect(() => runner.runSchematic('ng-add', {}, tree))
       .toThrow('Your app must have at least 1 project to use Playground.');
   });
@@ -283,3 +222,20 @@ const createPackageJson = () => `{
   },
   "devDependencies": {}
 }`;
+
+const verifyBasicFiles = (tree: UnitTestTree, options: { sourceRootPath: string, mainFilePath: string }) => {
+  // package.json
+  const packageJson = getJsonFileAsObject(tree, 'package.json');
+  expect(packageJson.scripts['playground']).toBe('angular-playground');
+  expect(packageJson.dependencies['angular-playground']).toBeUndefined();
+  expect(packageJson.devDependencies['angular-playground']).toBe('1.2.3');
+
+  // angular-playground.json
+  const angularPlaygroundJson = getJsonFileAsObject(tree, 'angular-playground.json');
+  expect(angularPlaygroundJson.sourceRoots).toEqual([options.sourceRootPath]);
+  expect(angularPlaygroundJson.angularCli.appName).toBe('playground');
+
+  // main.playground.ts
+  const mainFile = tree.readContent(options.mainFilePath);
+  expect(mainFile).toBeTruthy();
+};

--- a/packages/angular-playground/schematics/src/ng-add/index.ts
+++ b/packages/angular-playground/schematics/src/ng-add/index.ts
@@ -44,6 +44,7 @@ function addAppToWorkspaceFile(options: { stylesExtension: string }, workspace: 
   const projectRootParts = projectRoot.split('/');
   const sourceRoot = getSourceRoot(project.sourceRoot);
   const sourceRootParts = sourceRoot.split('/');
+  const tsConfigType = project.projectType === 'application' ? 'app' : 'lib';
 
   const newProject: Partial<WorkspaceProject> = {
     root: projectRoot,
@@ -57,7 +58,7 @@ function addAppToWorkspaceFile(options: { stylesExtension: string }, workspace: 
           index: constructPath([...sourceRootParts, 'index.html']),
           main: constructPath([...sourceRootParts, 'main.playground.ts']),
           polyfills: constructPath([...sourceRootParts, 'polyfills.ts']),
-          tsConfig: constructPath([...projectRootParts, 'tsconfig.app.json']),
+          tsConfig: constructPath([...projectRootParts, `tsconfig.${tsConfigType}.json`]),
           assets: [
             constructPath([...sourceRootParts, 'favicon.ico']),
             constructPath([...sourceRootParts, 'assets']),
@@ -103,15 +104,19 @@ function addAppToWorkspaceFile(options: { stylesExtension: string }, workspace: 
 function configure(options: any): Rule {
   return (host: Tree, context: SchematicContext) => {
     const workspace = getWorkspace(host);
-    const project = getProject(host, options);
+    const project = getProject(host, options, 'application');
 
     let stylesExtension = 'css';
-    if (project.architect) {
-      const mainStyle = project.architect.build.options.styles.find((path: string | { input: string }) => {
-        return typeof path === 'string'
+    if (
+      project.architect
+      && project.architect.build
+      && project.architect.build.options
+      && project.architect.build.options.styles
+    ) {
+      const mainStyle = project.architect.build.options.styles
+        .find((path: string | { input: string }) => typeof path === 'string'
           ? path.includes('/styles.')
-          : path.input.includes('/styles.');
-      });
+          : path.input.includes('/styles.'));
       if (mainStyle) {
         const mainStyleString = typeof mainStyle === 'string' ? mainStyle : mainStyle.input;
         stylesExtension = mainStyleString.split('.').pop();

--- a/packages/angular-playground/schematics/src/utils/project.ts
+++ b/packages/angular-playground/schematics/src/utils/project.ts
@@ -24,7 +24,11 @@ export function getProjectPath(
   return options.path;
 }
 
-export function getProject(host: Tree, options: { project?: string | undefined; path?: string | undefined }): WorkspaceProject {
+export function getProject(
+  host: Tree,
+  options: { project?: string | undefined; path?: string | undefined },
+  typeFilter: 'application' | 'library' | null = null,
+): WorkspaceProject {
   const workspace = getWorkspace(host);
 
   if (!options.project) {
@@ -33,7 +37,18 @@ export function getProject(host: Tree, options: { project?: string | undefined; 
     if (projectNames.length === 0) {
       throw new Error('Your app must have at least 1 project to use Playground.');
     }
-    options.project = projectNames[0];
+    // if type filter is not set, use first project
+    let firstFilteredProject = projectNames[0];
+    if (typeFilter) {
+      // apply filter
+      for (const projectName in workspace.projects) {
+        if (workspace.projects[projectName].projectType === typeFilter) {
+          firstFilteredProject = projectName;
+          break;
+        }
+      }
+    }
+    options.project = firstFilteredProject;
   }
 
   return workspace.projects[options.project];


### PR DESCRIPTION
fixes #204 

The issue was that we were just grabbing the first project in the workspace to find the proper style extension to use for the playground entry in angular.json. However, library entries do not have that setting so it resulted in an error.

Now, playground will search for the first project that is an application (which is enough to fix the reported issue), and check that the styles property is actually set (in case only library projects exist in the workspace).