### PR TITLE
fix(CLI): update --prod flag

### DIFF
--- a/projects/cli/src/build-angular-cli.ts
+++ b/projects/cli/src/build-angular-cli.ts
@@ -13,7 +13,7 @@ export async function buildAngularCli(appName: string, enableServiceWorker: bool
     const options = Number.isInteger(+maxBuffer) ? { maxBuffer: +maxBuffer } : {};
     // Cannot build w/ AOT due to runtime compiler dependency
     const flags = [
-        '--prod',
+        '--configuration production',
         '--aot=false',
         `--base-href=${baseHref}`,
         `--service-worker=${enableServiceWorker}`,


### PR DESCRIPTION
`--prod` has been deprecated with Angular 12, should use `--configuration production` instead as [explained in `ng build` docs](https://angular.io/cli/build).

This currently triggers an error when moving to Angular 13.