### PR TITLE
Update app.component.ts to work with Angular 19 seamlessly

### DIFF
--- a/projects/playground/src/lib/core/app.component.ts
+++ b/projects/playground/src/lib/core/app.component.ts
@@ -14,6 +14,7 @@ import { Sandboxes } from "./shared/sandboxes";
     selector: 'playground-app',
     templateUrl: './app.component.html',
     styleUrls: ['./app.component.css'],
+    standalone: false,
 })
 export class AppComponent implements OnInit {
     @ViewChildren('scenarioElement') scenarioLinkElements: QueryList<ElementRef>;


### PR DESCRIPTION
This is required in order to use `PlaygroundModule` while delcaring `AppComponent`. Simplest way forward :)