### PR TITLE
fix: Allow scenarios to work with Angular 19 and above

### DIFF
--- a/projects/playground/src/lib/core/scenario/scenario.component.ts
+++ b/projects/playground/src/lib/core/scenario/scenario.component.ts
@@ -157,6 +157,7 @@ export class ScenarioComponent implements OnInit, OnChanges, OnDestroy {
         }
 
         return Component({
+            standalone: true,
             selector: 'playground-host',
             template: scenario.template,
             styles: scenario.styles,


### PR DESCRIPTION
Fixes the following issue 

```
Error: Unexpected "DynamicComponent" found in the "declarations" array of the "DynamicModule" NgModule, "DynamicComponent" is marked as standalone and can't be declared in any NgModule - did you intend to import it instead (by adding it to the "imports" array)?
```
